### PR TITLE
Configurable sidebar link

### DIFF
--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -40,12 +40,13 @@ async function onCreateNode(
       }
     }
 
+    const {title, graphManagerUrl} = node.frontmatter;
     createPrinterNode({
       id: `${node.id} >>> Printer`,
       fileName,
       outputDir,
       data: {
-        title: node.frontmatter.title || siteName,
+        title: title || siteName,
         subtitle,
         category
       },
@@ -74,6 +75,12 @@ async function onCreateNode(
       name: 'slug',
       node,
       value: slug
+    });
+
+    actions.createNodeField({
+      name: 'graphManagerUrl',
+      node,
+      value: graphManagerUrl || ''
     });
   }
 }

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "2.3.4",
+  "version": "2.3.5-alpha.0",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/src/components/page-content.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/page-content.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 import SectionNav from './section-nav';
-import nest from 'recompose/nest';
 import styled from '@emotion/styled';
 import useMount from 'react-use/lib/useMount';
 import {IconGithub} from '@apollo/space-kit/icons/IconGithub';
+import {IconSchema} from '@apollo/space-kit/icons/IconSchema';
 import {
   PageNav,
   breakpoints,
@@ -130,30 +130,37 @@ const AsideHeading = styled.h4({
   fontWeight: 600
 });
 
-const AsideLink = nest(
-  styled.h5({
-    display: 'flex',
-    marginBottom: 0,
-    ':not(:last-child)': {
-      marginBottom: 16
-    }
-  }),
-  styled.a({
-    display: 'flex',
-    alignItems: 'center',
-    color: colors.text2,
-    textDecoration: 'none',
-    ':hover': {
-      color: colors.text3
-    },
-    svg: {
-      width: 20,
-      height: 20,
-      marginRight: 6,
-      fill: 'currentColor'
-    }
-  })
-);
+const AsideLinkWrapper = styled.h5({
+  display: 'flex',
+  marginBottom: 0,
+  ':not(:last-child)': {
+    marginBottom: 16
+  }
+});
+
+const AsideLinkInner = styled.a({
+  display: 'flex',
+  alignItems: 'center',
+  color: colors.text2,
+  textDecoration: 'none',
+  ':hover': {
+    color: colors.text3
+  },
+  svg: {
+    width: 20,
+    height: 20,
+    marginRight: 6,
+    fill: 'currentColor'
+  }
+});
+
+function AsideLink(props) {
+  return (
+    <AsideLinkWrapper>
+      <AsideLinkInner target="_blank" rel="noopener noreferrer" {...props} />
+    </AsideLinkWrapper>
+  );
+}
 
 const EditLink = styled.div({
   display: 'none',
@@ -248,6 +255,11 @@ export default function PageContent(props) {
             <SpectrumLogo /> Discuss on Spectrum
           </AsideLink>
         )}
+        {props.graphManagerUrl && (
+          <AsideLink href={props.graphManagerUrl}>
+            <IconSchema /> Demo Graph Manager
+          </AsideLink>
+        )}
       </Aside>
     </Container>
   );
@@ -260,6 +272,7 @@ PageContent.propTypes = {
   pages: PropTypes.array.isRequired,
   hash: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  graphManagerUrl: PropTypes.string.isRequired,
   headings: PropTypes.array.isRequired,
   spectrumUrl: PropTypes.string
 };

--- a/packages/gatsby-theme-apollo-docs/src/components/template.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/template.js
@@ -91,6 +91,7 @@ export default function Template(props) {
         <hr />
         <PageContent
           title={frontmatter.title}
+          graphManagerUrl={fields.graphManagerUrl}
           pathname={pathname}
           pages={pages}
           headings={headings}
@@ -147,6 +148,7 @@ export const pageQuery = graphql`
         }
         fields {
           image
+          graphManagerUrl
         }
         htmlAst
       }
@@ -160,6 +162,7 @@ export const pageQuery = graphql`
         }
         fields {
           image
+          graphManagerUrl
         }
         body
       }


### PR DESCRIPTION
Add support for a link to GM in the right sidebar, configurable with a `graphManagerUrl` frontmatter property.