### PR TITLE
WIP: Use @apollo/client in gatsby-theme-apollo

### DIFF
--- a/packages/gatsby-theme-apollo/README.md
+++ b/packages/gatsby-theme-apollo/README.md
@@ -4,7 +4,7 @@ A Gatsby theme that sets up your website for use with one of Apollo's React libr
 
 ## Installation
 
-If you're using this theme, you should already have a `@apollo/react-*` libary installed to do the data fetching in your components. We recommend that you use `@apollo/react-hooks`, but you might prefer `@apollo/react-components` or `@apollo/react-hoc`.
+This theme is meant to be used with the `@apollo/client` package. If you aren't already using it, make sure you install it along with this theme.
 
 ```bash
 $ npm install gatsby-theme-apollo
@@ -21,21 +21,24 @@ module.exports = {
 };
 ```
 
-**Required:** [Shadow](https://www.gatsbyjs.org/blog/2019-04-29-component-shadowing/) this theme's `client.js` file with your own Apollo client. This example uses `apollo-boost`, but you can use `apollo-client` if you have a more advanced use case. Check out the Apollo docs to learn more about [creating a client](https://www.apollographql.com/docs/react/essentials/get-started/#create-a-client) or [migrating from Apollo Boost](https://www.apollographql.com/docs/react/advanced/boost-migration/).
+**Required:** [Shadow](https://www.gatsbyjs.org/blog/2019-04-29-component-shadowing/) this theme's `client.js` file with your own Apollo client. Check out the Apollo docs to learn more about [creating a client](https://www.apollographql.com/docs/react/v3.0-beta/essentials/get-started/#create-a-client).
 
-However you decide to create your client, please ensure that:
+However you decide to create your client, you should make sure that:
 
 1. You provide an isomorphic `fetch` implementation as a configuration option
 2. Your client is the default export in `client.js`
 
 ```js
 // src/gatsby-theme-apollo/client.js
-import ApolloClient from 'apollo-boost';
 import fetch from 'isomorphic-fetch';
+import {ApolloClient, HttpLink, InMemoryCache} from '@apollo/client';
 
 const client = new ApolloClient({
-  fetch,
-  uri: 'https://api.spacex.land/graphql/'
+  cache: new InMemoryCache(),
+  link: new HttpLink({
+    uri: 'https://api.spacex.land/graphql/',
+    fetch
+  })
 });
 
 export default client;

--- a/packages/gatsby-theme-apollo/gatsby-browser.js
+++ b/packages/gatsby-theme-apollo/gatsby-browser.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import client from './src/client';
-import {ApolloProvider} from '@apollo/react-common';
+import {ApolloProvider} from '@apollo/client';
 
 // eslint-disable-next-line react/prop-types
 export const wrapRootElement = ({element}) => (

--- a/packages/gatsby-theme-apollo/package-lock.json
+++ b/packages/gatsby-theme-apollo/package-lock.json
@@ -4,14 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apollo/react-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.0.1.tgz",
-      "integrity": "sha512-7SC4qqPFo/41AhaQKCRovIshKkm4JLEGXyRHi+NPsaNJyk2J/HrWREnlHVqoPzYeIyq33f1L6j/NAkKn1NOnnQ==",
+    "@apollo/client": {
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.0.0-beta.1.tgz",
+      "integrity": "sha512-HxZ4kQWUFw+GtyA3/YOvQL7DmQnhPvfGbezeMDOOmdO2LzP6/fv7qEowas3Nh4rxNtx023Cp3EYV2PZRVAJ1Yg==",
       "dev": true,
       "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "@wry/equality": "^0.1.9",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.10.1",
+        "optimism": "^0.11.3",
+        "symbol-observable": "^1.2.0",
         "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
       }
     },
     "@babel/code-frame": {
@@ -1238,6 +1245,12 @@
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM=",
       "dev": true
     },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
@@ -1466,6 +1479,24 @@
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@wry/context": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.0.tgz",
+      "integrity": "sha512-yW5XFrWbRvv2/f86+g0YAfko7671SQg7Epn8lYjux4MZmIvtPvK2ts+vG1QAPu2w6GuBioEJknRa7K2LFj2kQw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "@xtuc/ieee754": {
@@ -7148,6 +7179,12 @@
         "cross-fetch": "2.2.2"
       }
     },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
+      "dev": true
+    },
     "graphql-type-json": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
@@ -9602,6 +9639,15 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.11.4.tgz",
+      "integrity": "sha512-a9dQJt/dvrxhkEGK/l1U+T4zJ9OyIOWGnRrbjxy8+mWHVR3C3phmKlRuh2YKkSVjTf8G1kVFVEqL9+s4E77wsg==",
+      "dev": true,
+      "requires": {
+        "@wry/context": "^0.5.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -14491,6 +14537,12 @@
           }
         }
       }
+    },
+    "zen-observable": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
+      "dev": true
     }
   }
 }

--- a/packages/gatsby-theme-apollo/package.json
+++ b/packages/gatsby-theme-apollo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo",
-  "version": "2.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "index.js",
   "description": "Sets up your Gatsby website for use with Apollo",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo/package.json
+++ b/packages/gatsby-theme-apollo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-beta.0",
   "main": "index.js",
   "description": "Sets up your Gatsby website for use with Apollo",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo/package.json
+++ b/packages/gatsby-theme-apollo/package.json
@@ -16,11 +16,11 @@
     "apollo-client"
   ],
   "peerDependencies": {
-    "@apollo/react-common": ">=3.0.0",
+    "@apollo/client": ">=3.0.0-beta.1",
     "gatsby": ">=2.13.80"
   },
   "devDependencies": {
-    "@apollo/react-common": "^3.0.1",
+    "@apollo/client": "^3.0.0-beta.1",
     "gatsby": "^2.13.80"
   }
 }


### PR DESCRIPTION
This branch updates `gatsby-theme-apollo` to use Apollo Client 3. It shouldn't be merged into master until https://github.com/apollographql/apollo-client/pull/5116 gets merged.