### PR TITLE
Make the responsiveSidebar hook more useful

### DIFF
--- a/packages/gatsby-theme-apollo-core/package.json
+++ b/packages/gatsby-theme-apollo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-core",
-  "version": "3.0.0",
+  "version": "3.0.1-alpha.0",
   "main": "index.js",
   "description": "A theme for bootstrapping Gatsby websites at Apollo",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-core/package.json
+++ b/packages/gatsby-theme-apollo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-core",
-  "version": "3.0.1-alpha.0",
+  "version": "3.0.1-alpha.1",
   "main": "index.js",
   "description": "A theme for bootstrapping Gatsby websites at Apollo",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-core/src/components/responsive-sidebar.js
+++ b/packages/gatsby-theme-apollo-core/src/components/responsive-sidebar.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import useKey from 'react-use/lib/useKey';
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 
 export function useResponsiveSidebar() {
+  const sidebarRef = useRef(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useKey(
@@ -20,10 +21,18 @@ export function useResponsiveSidebar() {
     setSidebarOpen(false);
   }
 
+  function handleWrapperClick(event) {
+    if (sidebarOpen && !sidebarRef.current.contains(event.target)) {
+      closeSidebar();
+    }
+  }
+
   return {
     sidebarOpen,
     openSidebar,
-    closeSidebar
+    closeSidebar,
+    sidebarRef,
+    handleWrapperClick
   };
 }
 

--- a/packages/gatsby-theme-apollo-core/src/components/responsive-sidebar.js
+++ b/packages/gatsby-theme-apollo-core/src/components/responsive-sidebar.js
@@ -32,7 +32,8 @@ export function useResponsiveSidebar() {
     openSidebar,
     closeSidebar,
     sidebarRef,
-    handleWrapperClick
+    handleWrapperClick,
+    handleSidebarNavLinkClick: sidebarOpen ? closeSidebar : null
   };
 }
 

--- a/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/index.js
+++ b/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/index.js
@@ -75,7 +75,7 @@ function isPageSelected(path, pathname) {
 
 function isCategorySelected({path, pages}, pathname) {
   return path
-    ? isPageSelected({path})
+    ? isPageSelected(path, pathname)
     : pages.some(page => isPageSelected(page.path, pathname));
 }
 

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.4-alpha.0",
+  "version": "3.1.4-alpha.1",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",
@@ -31,7 +31,7 @@
     "gatsby-remark-typescript": "0.0.9",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-source-git": "^1.0.1",
-    "gatsby-theme-apollo-core": "^3.0.1-alpha.0",
+    "gatsby-theme-apollo-core": "^3.0.1-alpha.1",
     "gatsby-transformer-remark": "^2.6.30",
     "js-yaml": "^3.13.1",
     "prismjs": "^1.15.0",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.3",
+  "version": "3.1.4-alpha.0",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",
@@ -31,7 +31,7 @@
     "gatsby-remark-typescript": "0.0.9",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-source-git": "^1.0.1",
-    "gatsby-theme-apollo-core": "^3.0.0",
+    "gatsby-theme-apollo-core": "^3.0.1-alpha.0",
     "gatsby-transformer-remark": "^2.6.30",
     "js-yaml": "^3.13.1",
     "prismjs": "^1.15.0",

--- a/packages/gatsby-theme-apollo-docs/src/components/page-layout.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/page-layout.js
@@ -107,8 +107,6 @@ function handleToggleCategory(title, expanded) {
 export const NavItemsContext = createContext();
 
 export default function PageLayout(props) {
-  const sidebarRef = useRef(null);
-
   const data = useStaticQuery(
     graphql`
       {
@@ -123,7 +121,13 @@ export default function PageLayout(props) {
     `
   );
 
-  const {openSidebar, closeSidebar, sidebarOpen} = useResponsiveSidebar();
+  const {
+    openSidebar,
+    closeSidebar,
+    sidebarOpen,
+    handleWrapperClick,
+    sidebarRef
+  } = useResponsiveSidebar();
 
   const buttonRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -134,12 +138,6 @@ export default function PageLayout(props) {
 
   function closeMenu() {
     setMenuOpen(false);
-  }
-
-  function handleWrapperClick(event) {
-    if (sidebarOpen && !sidebarRef.current.contains(event.target)) {
-      closeSidebar();
-    }
   }
 
   const {pathname} = props.location;

--- a/packages/gatsby-theme-apollo-docs/src/components/page-layout.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/page-layout.js
@@ -122,11 +122,11 @@ export default function PageLayout(props) {
   );
 
   const {
+    sidebarRef,
     openSidebar,
-    closeSidebar,
     sidebarOpen,
     handleWrapperClick,
-    sidebarRef
+    handleSidebarNavLinkClick
   } = useResponsiveSidebar();
 
   const buttonRef = useRef(null);
@@ -231,7 +231,7 @@ export default function PageLayout(props) {
               pathname={pathname}
               onToggleAll={handleToggleAll}
               onToggleCategory={handleToggleCategory}
-              onLinkClick={sidebarOpen ? closeSidebar : null}
+              onLinkClick={handleSidebarNavLinkClick}
             />
           )}
         </Sidebar>


### PR DESCRIPTION
Share more info (like click handlers) from the responsive sidebar hook in the core theme.