### PR TITLE
Use remark-typescript

### DIFF
--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -1,3 +1,4 @@
+const remarkTypescript = require('remark-typescript');
 const {colors} = require('gatsby-theme-apollo-core/src/utils/colors');
 
 module.exports = ({
@@ -87,7 +88,7 @@ module.exports = ({
       options: {
         gatsbyRemarkPlugins,
         remarkPlugins: [
-          ['remark-typescript', {wrapperComponent: 'MultiCodeBlock'}]
+          [remarkTypescript, {wrapperComponent: 'MultiCodeBlock'}]
         ]
       }
     },

--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -85,14 +85,9 @@ module.exports = ({
     {
       resolve: 'gatsby-plugin-mdx',
       options: {
-        gatsbyRemarkPlugins: [
-          {
-            resolve: 'gatsby-remark-typescript',
-            options: {
-              wrapperComponent: 'MultiCodeBlock'
-            }
-          },
-          ...gatsbyRemarkPlugins
+        gatsbyRemarkPlugins,
+        remarkPlugins: [
+          ['remark-typescript', {wrapperComponent: 'MultiCodeBlock'}]
         ]
       }
     },

--- a/packages/gatsby-theme-apollo-docs/package-lock.json
+++ b/packages/gatsby-theme-apollo-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.12-alpha.0",
+  "version": "3.1.12-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8222,6 +8222,23 @@
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
           "dev": true
         },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+          "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -8235,6 +8252,37 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+          "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.7.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          },
+          "dependencies": {
+            "is-wsl": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+              "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
           }
         },
         "unique-string": {
@@ -8253,6 +8301,24 @@
           "dev": true,
           "requires": {
             "prepend-http": "^2.0.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
           }
         },
         "write-file-atomic": {
@@ -15533,9 +15599,9 @@
       }
     },
     "remark-typescript": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.2.4.tgz",
-      "integrity": "sha512-1mXI/xOD3wpVZ83EYvgcVX9m8DjmOC7eOI1ybK8eUGxKgQxVtkdc843oPQ7AvfWGIzeXN45RUBmVuOtbqlvCBg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.3.0.tgz",
+      "integrity": "sha512-c0BIzd3v5pEpaMtcWc/BoP5OFkhAcUjwjXaY6rC6ospQsQN7SxX6WNdZOsGIH1KIyZ6dk+aAX4jSNdf5JsZhYQ==",
       "requires": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",
@@ -17458,16 +17524,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -17490,6 +17556,12 @@
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
           }
+        },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+          "dev": true
         },
         "source-list-map": {
           "version": "2.0.1",

--- a/packages/gatsby-theme-apollo-docs/package-lock.json
+++ b/packages/gatsby-theme-apollo-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.11",
+  "version": "3.1.12-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15533,9 +15533,9 @@
       }
     },
     "remark-typescript": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.2.2.tgz",
-      "integrity": "sha512-AR0rR7xgmzp5KP8SFXr9RudT9GI4ubMUN8lGcTX3vjFBwnmXZGrOnvlMxnFbkI1F4PpJeiSpZdyqChbO4C4rBA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.2.4.tgz",
+      "integrity": "sha512-1mXI/xOD3wpVZ83EYvgcVX9m8DjmOC7eOI1ybK8eUGxKgQxVtkdc843oPQ7AvfWGIzeXN45RUBmVuOtbqlvCBg==",
       "requires": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",

--- a/packages/gatsby-theme-apollo-docs/package-lock.json
+++ b/packages/gatsby-theme-apollo-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -784,9 +784,9 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "requires": {
             "@babel/types": "^7.7.4",
             "jsesc": "^2.5.1",
@@ -861,9 +861,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
         },
         "@babel/template": {
           "version": "7.7.4",
@@ -993,9 +993,9 @@
       }
     },
     "@babel/preset-typescript": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.4.tgz",
-      "integrity": "sha512-rqrjxfdiHPsnuPur0jKrIIGQCIgoTWMTjlbWE69G4QJ6TIOVnnRnIJhUxNTL/VwDmEAVX08Tq3B1nirer5341w==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.7.tgz",
+      "integrity": "sha512-Apg0sCTovsSA+pEaI8efnA44b9x4X/7z4P8vsWMiN8rSUaM4y4+Shl5NMWnMl6njvt96+CEb6jwpXAKYAVCSQA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-typescript": "^7.7.4"
@@ -8672,27 +8672,6 @@
         "unist-util-visit": "^2.0.0"
       }
     },
-    "gatsby-remark-typescript": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-typescript/-/gatsby-remark-typescript-0.2.1.tgz",
-      "integrity": "sha512-LHYsheXzX3bxhxpO2R05zPzNBC3w7QokrNK4B7wEd34MHa7qmSI7HYLuLSmtJpnn6ftRl8troCxqXn/xTmx6kg==",
-      "requires": {
-        "@babel/core": "^7.5.5",
-        "@babel/preset-typescript": "^7.3.3",
-        "prettier": "^1.18.2",
-        "unist-util-visit": "^1.4.1"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
-      }
-    },
     "gatsby-source-filesystem": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.18.tgz",
@@ -15551,6 +15530,27 @@
         "stringify-entities": "^1.0.1",
         "unherit": "^1.0.4",
         "xtend": "^4.0.1"
+      }
+    },
+    "remark-typescript": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.2.2.tgz",
+      "integrity": "sha512-AR0rR7xgmzp5KP8SFXr9RudT9GI4ubMUN8lGcTX3vjFBwnmXZGrOnvlMxnFbkI1F4PpJeiSpZdyqChbO4C4rBA==",
+      "requires": {
+        "@babel/core": "^7.5.5",
+        "@babel/preset-typescript": "^7.3.3",
+        "prettier": "^1.18.2",
+        "unist-util-visit": "^1.4.1"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
       }
     },
     "remove-trailing-separator": {

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -28,7 +28,6 @@
     "gatsby-remark-prismjs": "^3.2.8",
     "gatsby-remark-prismjs-title": "^1.0.0",
     "gatsby-remark-rewrite-relative-links": "^1.0.7",
-    "gatsby-remark-typescript": "^0.2.1",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-source-git": "^1.0.1",
     "gatsby-theme-apollo-core": "^3.0.3",
@@ -40,6 +39,7 @@
     "rehype-react": "^3.1.0",
     "remark": "^10.0.1",
     "remark-react": "^5.0.1",
+    "remark-typescript": "^0.2.2",
     "source-sans-pro": "^3.6.0",
     "striptags": "^3.1.1"
   },

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.12-alpha.0",
+  "version": "3.1.12-alpha.1",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.11",
+  "version": "3.1.12-alpha.0",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -39,7 +39,7 @@
     "rehype-react": "^3.1.0",
     "remark": "^10.0.1",
     "remark-react": "^5.0.1",
-    "remark-typescript": "^0.2.4",
+    "remark-typescript": "^0.3.0",
     "source-sans-pro": "^3.6.0",
     "striptags": "^3.1.1"
   },

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -39,7 +39,7 @@
     "rehype-react": "^3.1.0",
     "remark": "^10.0.1",
     "remark-react": "^5.0.1",
-    "remark-typescript": "^0.2.2",
+    "remark-typescript": "^0.2.4",
     "source-sans-pro": "^3.6.0",
     "striptags": "^3.1.1"
   },

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.12-alpha.2",
+  "version": "3.1.12-alpha.3",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.1.12-alpha.1",
+  "version": "3.1.12-alpha.2",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",


### PR DESCRIPTION
This branch uses `remark-typescript` instead of the now-deprecated `gatsby-remark-typescript`