### PR TITLE
Documentation fix

### DIFF
--- a/packages/gatsby-theme-apollo-core/README.md
+++ b/packages/gatsby-theme-apollo-core/README.md
@@ -33,7 +33,7 @@ $ npm install gatsby gatsby-theme-apollo-core
 ```js
 // gatsby-config.js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: 'gatsby-theme-apollo-core',
       options: {


### PR DESCRIPTION
Since gatsby themes are released, themes must be in plugins section of gatsby-config(seems like you forget to update docs :) )