### PR TITLE
Use contentDir option wherever possible

### DIFF
--- a/packages/gatsby-theme-apollo-docs/README.md
+++ b/packages/gatsby-theme-apollo-docs/README.md
@@ -65,28 +65,29 @@ module.exports = {
 };
 ```
 
-| Option name       | Type   | Description                                                                                                                  |
-| ----------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| root              | string | Must be `__dirname`                                                                                                          |
-| siteName          | string | The main title for the website, used in the `<title>` element and top left corner of the site                                |
-| subtitle          | string | The page title that gets rendered above the sidebar navigation                                                               |
-| description       | string | The site description for SEO and social (FB, Twitter) tags                                                                   |
-| contentDir        | string | The directory where docs content exists (`docs/source` by default)                                                           |
-| githubRepo        | string | The owner and name of the content repository on GitHub                                                                       |
-| spectrumPath      | string | The path to be appended to Spectrum links                                                                                    |
-| segmentApiKey     | string | Your [Segment](https://segment.com/) API key                                                                                 |
-| algoliaApiKey     | string | Your [Algolia DocSearch](https://community.algolia.com/docsearch/) API key                                                   |
-| algoliaIndexName  | string | The name of your DocSearch index                                                                                             |
-| baseUrl           | string | The origin where your website will be hosted (e.g. `https://www.apollographql.com`)                                          |
-| spectrumHandle    | string | Your Spectrum community's handle/slug                                                                                        |
-| twitterHandle     | string | Your Twitter handle, without the "@"                                                                                         |
-| youtubeUrl        | string | The URL of your YouTube channel                                                                                              |
-| defaultVersion    | string | An identifier for the default selected version, served at the root of the docset (/)                                         |
-| localVersion      | string | If the local files represent a version different from the `defaultVersion`, specify an identifier for the local version here |
-| versions          | array  | An array of objects representing the versions that the website should generate                                               |
-| sidebarCategories | object | An object mapping categories to page paths (see [`sidebarCategories` reference](#sidebarcategories))                         |
-| navConfig         | object | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                   |
-| checkLinksOptions | object | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)         |
+| Option name       | Type   | Description                                                                                                                               |
+| ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| root              | string | Must be `__dirname`                                                                                                                       |
+| siteName          | string | The main title for the website, used in the `<title>` element and top left corner of the site                                             |
+| subtitle          | string | The page title that gets rendered above the sidebar navigation                                                                            |
+| description       | string | The site description for SEO and social (FB, Twitter) tags                                                                                |
+| contentDir        | string | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (`'docs'`, for example) |
+| contentDir        | string | The directory where docs content exists (`'source'` by default)                                                                           |
+| githubRepo        | string | The owner and name of the content repository on GitHub                                                                                    |
+| spectrumPath      | string | The path to be appended to Spectrum links                                                                                                 |
+| segmentApiKey     | string | Your [Segment](https://segment.com/) API key                                                                                              |
+| algoliaApiKey     | string | Your [Algolia DocSearch](https://community.algolia.com/docsearch/) API key                                                                |
+| algoliaIndexName  | string | The name of your DocSearch index                                                                                                          |
+| baseUrl           | string | The origin where your website will be hosted (e.g. `https://www.apollographql.com`)                                                       |
+| spectrumHandle    | string | Your Spectrum community's handle/slug                                                                                                     |
+| twitterHandle     | string | Your Twitter handle, without the "@"                                                                                                      |
+| youtubeUrl        | string | The URL of your YouTube channel                                                                                                           |
+| defaultVersion    | string | An identifier for the default selected version, served at the root of the docset (/)                                                      |
+| localVersion      | string | If the local files represent a version different from the `defaultVersion`, specify an identifier for the local version here              |
+| versions          | array  | An array of objects representing the versions that the website should generate                                                            |
+| sidebarCategories | object | An object mapping categories to page paths (see [`sidebarCategories` reference](#sidebarcategories))                                      |
+| navConfig         | object | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                                |
+| checkLinksOptions | object | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)                      |
 
 ### `versions`
 

--- a/packages/gatsby-theme-apollo-docs/README.md
+++ b/packages/gatsby-theme-apollo-docs/README.md
@@ -65,29 +65,29 @@ module.exports = {
 };
 ```
 
-| Option name       | Type   | Description                                                                                                                               |
-| ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| root              | string | Must be `__dirname`                                                                                                                       |
-| siteName          | string | The main title for the website, used in the `<title>` element and top left corner of the site                                             |
-| subtitle          | string | The page title that gets rendered above the sidebar navigation                                                                            |
-| description       | string | The site description for SEO and social (FB, Twitter) tags                                                                                |
-| contentDir        | string | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (`'docs'`, for example) |
-| contentDir        | string | The directory where docs content exists (`'source'` by default)                                                                           |
-| githubRepo        | string | The owner and name of the content repository on GitHub                                                                                    |
-| spectrumPath      | string | The path to be appended to Spectrum links                                                                                                 |
-| segmentApiKey     | string | Your [Segment](https://segment.com/) API key                                                                                              |
-| algoliaApiKey     | string | Your [Algolia DocSearch](https://community.algolia.com/docsearch/) API key                                                                |
-| algoliaIndexName  | string | The name of your DocSearch index                                                                                                          |
-| baseUrl           | string | The origin where your website will be hosted (e.g. `https://www.apollographql.com`)                                                       |
-| spectrumHandle    | string | Your Spectrum community's handle/slug                                                                                                     |
-| twitterHandle     | string | Your Twitter handle, without the "@"                                                                                                      |
-| youtubeUrl        | string | The URL of your YouTube channel                                                                                                           |
-| defaultVersion    | string | An identifier for the default selected version, served at the root of the docset (/)                                                      |
-| localVersion      | string | If the local files represent a version different from the `defaultVersion`, specify an identifier for the local version here              |
-| versions          | array  | An array of objects representing the versions that the website should generate                                                            |
-| sidebarCategories | object | An object mapping categories to page paths (see [`sidebarCategories` reference](#sidebarcategories))                                      |
-| navConfig         | object | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                                |
-| checkLinksOptions | object | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)                      |
+| Option name       | Type   | Description                                                                                                                             |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| root              | string | Must be `__dirname`                                                                                                                     |
+| siteName          | string | The main title for the website, used in the `<title>` element and top left corner of the site                                           |
+| subtitle          | string | The page title that gets rendered above the sidebar navigation                                                                          |
+| description       | string | The site description for SEO and social (FB, Twitter) tags                                                                              |
+| contentDir        | string | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (`docs`, for example) |
+| contentDir        | string | The directory where docs content exists (`content` by default)                                                                          |
+| githubRepo        | string | The owner and name of the content repository on GitHub                                                                                  |
+| spectrumPath      | string | The path to be appended to Spectrum links                                                                                               |
+| segmentApiKey     | string | Your [Segment](https://segment.com/) API key                                                                                            |
+| algoliaApiKey     | string | Your [Algolia DocSearch](https://community.algolia.com/docsearch/) API key                                                              |
+| algoliaIndexName  | string | The name of your DocSearch index                                                                                                        |
+| baseUrl           | string | The origin where your website will be hosted (e.g. `https://www.apollographql.com`)                                                     |
+| spectrumHandle    | string | Your Spectrum community's handle/slug                                                                                                   |
+| twitterHandle     | string | Your Twitter handle, without the "@"                                                                                                    |
+| youtubeUrl        | string | The URL of your YouTube channel                                                                                                         |
+| defaultVersion    | string | An identifier for the default selected version, served at the root of the docset (/)                                                    |
+| localVersion      | string | If the local files represent a version different from the `defaultVersion`, specify an identifier for the local version here            |
+| versions          | array  | An array of objects representing the versions that the website should generate                                                          |
+| sidebarCategories | object | An object mapping categories to page paths (see [`sidebarCategories` reference](#sidebarcategories))                                    |
+| navConfig         | object | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                              |
+| checkLinksOptions | object | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)                    |
 
 ### `versions`
 

--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const remarkTypescript = require('remark-typescript');
 const {colors} = require('gatsby-theme-apollo-core/src/utils/colors');
 const {HEADER_HEIGHT} = require('./src/utils');
@@ -8,6 +9,8 @@ module.exports = ({
   subtitle,
   description,
   githubRepo,
+  baseDir = '',
+  contentDir = 'source',
   versions = {},
   segmentApiKey,
   checkLinksOptions,
@@ -70,16 +73,11 @@ module.exports = ({
   ];
 
   const plugins = [
-    {
-      resolve: 'gatsby-theme-apollo-core',
-      options: {
-        root
-      }
-    },
+    'gatsby-theme-apollo-core',
     {
       resolve: 'gatsby-source-filesystem',
       options: {
-        path: `${root}/source`,
+        path: path.join(root, contentDir),
         name: 'docs'
       }
     },
@@ -106,9 +104,9 @@ module.exports = ({
         branch,
         remote: `https://github.com/${githubRepo}`,
         patterns: [
-          'docs/source/**',
-          'docs/gatsby-config.js',
-          'docs/_config.yml'
+          path.join(baseDir, contentDir, '**'),
+          path.join(baseDir, 'gatsby-config.js'),
+          path.join(baseDir, '_config.yml')
         ]
       }
     }))

--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -119,7 +119,7 @@ function getPageFromEdge({node}) {
   return node.childMarkdownRemark || node.childMdx;
 }
 
-function getSidebarContents(sidebarCategories, edges, version, contentDir) {
+function getSidebarContents(sidebarCategories, edges, version, dirPattern) {
   return Object.keys(sidebarCategories).map(key => ({
     title: key === 'null' ? null : key,
     pages: sidebarCategories[key]
@@ -140,7 +140,7 @@ function getSidebarContents(sidebarCategories, edges, version, contentDir) {
             fields.version === version &&
             relativePath
               .slice(0, relativePath.lastIndexOf('.'))
-              .replace(new RegExp(`^${contentDir}/`), '') === linkPath
+              .replace(dirPattern, '') === linkPath
           );
         });
 
@@ -236,12 +236,14 @@ exports.createPages = async (
 
   const {edges} = data.allFile;
   const mainVersion = localVersion || defaultVersion;
+  const contentPath = path.join(baseDir, contentDir);
+  const dirPattern = new RegExp(`^${contentPath}/`);
   const sidebarContents = {
     [mainVersion]: getSidebarContents(
       sidebarCategories,
       edges,
       mainVersion,
-      contentDir
+      dirPattern
     )
   };
 
@@ -277,7 +279,7 @@ exports.createPages = async (
       getVersionSidebarCategories(...configs),
       edges,
       version,
-      contentDir
+      dirPattern
     );
   }
 
@@ -320,6 +322,7 @@ exports.createPages = async (
             repo,
             'tree',
             'master',
+            baseDir,
             contentDir,
             relativePath
           ),

--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -75,9 +75,11 @@ async function onCreateNode(
       value: path.join(outputDir, fileName + '.png')
     });
 
+    let versionRef = '';
     if (parent.gitRemote___NODE) {
       const gitRemote = getNode(parent.gitRemote___NODE);
       version = gitRemote.sourceInstanceName;
+      versionRef = gitRemote.ref;
 
       const dirPattern = new RegExp(path.join('^', baseDir, contentDir));
       slug = slug.replace(dirPattern, '');
@@ -88,26 +90,32 @@ async function onCreateNode(
     }
 
     actions.createNodeField({
-      name: 'version',
       node,
+      name: 'version',
       value: version
     });
 
     actions.createNodeField({
-      name: 'slug',
       node,
+      name: 'versionRef',
+      value: versionRef
+    });
+
+    actions.createNodeField({
+      node,
+      name: 'slug',
       value: slug
     });
 
     actions.createNodeField({
-      name: 'sidebarTitle',
       node,
+      name: 'sidebarTitle',
       value: sidebar_title || ''
     });
 
     actions.createNodeField({
-      name: 'graphManagerUrl',
       node,
+      name: 'graphManagerUrl',
       value: graphManagerUrl || ''
     });
   }
@@ -195,6 +203,7 @@ const pageFragment = `
   fields {
     slug
     version
+    versionRef
     sidebarTitle
   }
 `;
@@ -238,6 +247,7 @@ exports.createPages = async (
   const mainVersion = localVersion || defaultVersion;
   const contentPath = path.join(baseDir, contentDir);
   const dirPattern = new RegExp(`^${contentPath}/`);
+
   const sidebarContents = {
     [mainVersion]: getSidebarContents(
       sidebarCategories,
@@ -321,9 +331,7 @@ exports.createPages = async (
             owner,
             repo,
             'tree',
-            'master',
-            baseDir,
-            contentDir,
+            fields.versionRef || path.join('master', contentPath),
             relativePath
           ),
         spectrumUrl:

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "3.2.7",
+  "version": "4.0.0-alpha.0",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-docs/theme-options.js
+++ b/packages/gatsby-theme-apollo-docs/theme-options.js
@@ -59,6 +59,8 @@ module.exports = {
   youtubeUrl: 'https://www.youtube.com/channel/UC0pEW_GOrMJ23l8QcrGdKSw',
   logoLink: 'https://www.apollographql.com/docs/',
   defaultVersion: 'default',
+  baseDir: 'docs',
+  contentDir: 'source',
   navConfig,
   footerNavConfig
 };


### PR DESCRIPTION
This PR addresses #87, using the `contentDir` option wherever appropriate. As I was implementing this change, I realized there was a need for more granularity in the way we treat directories.

Previously, `contentDir`'s default value was `docs/source`. In Apollo's repos, the `docs` directory is the place where that repo's Gatsby website lives; `source` is the directory within the Gatsby project where the markdown exists. In order to do support a custom `contentDir` we had to split these two ideas up to target files or paths during the build, relative to the website root (`docs/gatsby-config.js`) OR content root (`docs/source/whatever.md`).

Now, you can set either option individually using the `baseDir` and `contentDir` options. In Apollo's case, we will use a config like this:

```js
{
  baseDir: 'docs',
  contentDir: 'source'
}
```

Since this is already a breaking change, I thought I'd set the default `contentDir` to a more sensible name like "content", since it's common for a Gatsby site to already have a "src" directory, so adding a "source" directory alongside it seems awkward.