### PR TITLE
Fix/spectrum

### DIFF
--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -348,7 +348,7 @@ exports.createPages = async (
         githubUrl,
         spectrumUrl:
           spectrumHandle &&
-          (getSpectrumUrl(spectrumHandle) + spectrumPath || `/${repoPath}`),
+          getSpectrumUrl(spectrumHandle) + (spectrumPath || repoPath),
         twitterHandle,
         typescriptApiBox,
         versions: versionKeys, // only need to send version labels to client

--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -318,7 +318,7 @@ exports.createPages = async (
     }
 
     let githubUrl;
-    let spectrumUrl = spectrumHandle && getSpectrumUrl(spectrumHandle);
+    let repoPath;
 
     if (githubRepo) {
       const [owner, repo] = githubRepo.split('/');
@@ -333,9 +333,7 @@ exports.createPages = async (
           relativePath
         );
 
-      spectrumUrl += spectrumPath || `/${repo}`;
-    } else {
-      spectrumUrl += spectrumPath;
+      repoPath = `/${repo}`;
     }
 
     actions.createPage({
@@ -348,7 +346,9 @@ exports.createPages = async (
         versionBasePath: getVersionBasePath(fields.version),
         sidebarContents: sidebarContents[fields.version],
         githubUrl,
-        spectrumUrl,
+        spectrumUrl:
+          spectrumHandle &&
+          (getSpectrumUrl(spectrumHandle) + spectrumPath || `/${repoPath}`),
         twitterHandle,
         typescriptApiBox,
         versions: versionKeys, // only need to send version labels to client


### PR DESCRIPTION
When no spectrum handle is passed in the gatsby-config it should be expected to not see the
`discuss on spectrum` button on the page but it was still showing. Added simple check to tell the node config to return the spectrum url dependent on whether the handle is undefined or not.

Side note: Let me know if you need me to fix the spacing with the brackets. I wasn't going to dig in and find the setting that does this put I am using the default prettier settings in vscode. The linter must not have a config setting in the workspace for spacing.