### PR TITLE
Make crawlable by Algolia

### DIFF
--- a/packages/gatsby-theme-apollo-core/package-lock.json
+++ b/packages/gatsby-theme-apollo-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-core",
-  "version": "2.3.0-alpha.3",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-theme-apollo-core/package.json
+++ b/packages/gatsby-theme-apollo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-core",
-  "version": "3.0.8",
+  "version": "3.0.9-alpha.0",
   "main": "index.js",
   "description": "A theme for bootstrapping Gatsby websites at Apollo",
   "author": "Trevor Blades <blades@apollographql.com>",

--- a/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/category.js
+++ b/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/category.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
-import {IconArrowDown} from '@apollo/space-kit/icons/IconArrowDown';
-import {IconArrowUp} from '@apollo/space-kit/icons/IconArrowUp';
 import {Link} from 'gatsby';
 import {colors} from '../../utils/colors';
 import {smallCaps} from '../../utils/typography';
@@ -49,15 +47,14 @@ const StyledLink = styled(Link)(headingStyles, {
 });
 
 export default function Category(props) {
-  const Icon = props.expanded ? IconArrowUp : IconArrowDown;
   const contents = (
     <Fragment>
       <h6>{props.title}</h6>
-      <Icon
-        style={{
+      {React.createElement(props.icon, {
+        style: {
           visibility: props.onClick ? 'visible' : 'hidden'
-        }}
-      />
+        }
+      })}
     </Fragment>
   );
 
@@ -76,7 +73,7 @@ export default function Category(props) {
           {contents}
         </StyledButton>
       )}
-      {props.expanded && props.children}
+      {props.children}
     </div>
   );
 }
@@ -84,7 +81,7 @@ export default function Category(props) {
 Category.propTypes = {
   title: PropTypes.string.isRequired,
   path: PropTypes.string,
-  expanded: PropTypes.bool.isRequired,
+  icon: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   active: PropTypes.bool.isRequired,
   onClick: PropTypes.func

--- a/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/index.js
+++ b/packages/gatsby-theme-apollo-core/src/components/sidebar-nav/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React, {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import usePrevious from 'react-use/lib/usePrevious';
+import {IconArrowDown} from '@apollo/space-kit/icons/IconArrowDown';
+import {IconArrowUp} from '@apollo/space-kit/icons/IconArrowUp';
 import {IconCollapseList} from '@apollo/space-kit/icons/IconCollapseList';
 import {IconExpandList} from '@apollo/space-kit/icons/IconExpandList';
 import {IconOutlink} from '@apollo/space-kit/icons/IconOutlink';
@@ -154,39 +156,33 @@ export default function SidebarNav(props) {
   return (
     <Fragment>
       {props.contents.map(({title, path, pages}, index, array) => {
-        const contents = (
-          <StyledList>
-            {pages.map(page => (
-              <StyledListItem key={page.path}>
-                {page.anchor ? (
-                  <a href={page.path} target="_blank" rel="noopener noreferrer">
-                    {page.title}
-                    <StyledOutlinkIcon />
-                  </a>
-                ) : (
-                  <Link
-                    className={
-                      isPageSelected(page.path, props.pathname)
-                        ? 'active'
-                        : null
-                    }
-                    to={page.path}
-                    title={page.description}
-                    onClick={props.onLinkClick}
-                  >
-                    {page.title}
-                  </Link>
-                )}
-              </StyledListItem>
-            ))}
-          </StyledList>
-        );
+        const contents = pages.map(page => (
+          <StyledListItem key={page.path}>
+            {page.anchor ? (
+              <a href={page.path} target="_blank" rel="noopener noreferrer">
+                {page.title}
+                <StyledOutlinkIcon />
+              </a>
+            ) : (
+              <Link
+                className={
+                  isPageSelected(page.path, props.pathname) ? 'active' : null
+                }
+                to={page.path}
+                title={page.description}
+                onClick={props.onLinkClick}
+              >
+                {page.title}
+              </Link>
+            )}
+          </StyledListItem>
+        ));
 
         if (!title) {
           const Icon = allExpanded ? IconCollapseList : IconExpandList;
           return (
             <Fragment key="root">
-              {contents}
+              <StyledList>{contents}</StyledList>
               {array.length > 2 && (
                 <ExpandAll onClick={toggleAll}>
                   <Icon />
@@ -197,16 +193,23 @@ export default function SidebarNav(props) {
           );
         }
 
+        const isExpanded = state[getId(title)] || props.alwaysExpanded;
         return (
           <Category
             key={title}
             title={title}
             path={path}
-            expanded={Boolean(state[getId(title)] || props.alwaysExpanded)}
+            icon={isExpanded ? IconArrowUp : IconArrowDown}
             active={isCategorySelected({pages, path}, props.pathname)}
             onClick={props.alwaysExpanded ? null : toggleCategory}
           >
-            {contents}
+            <StyledList
+              style={{
+                display: isExpanded ? 'block' : 'none'
+              }}
+            >
+              {contents}
+            </StyledList>
           </Category>
         );
       })}

--- a/packages/gatsby-theme-apollo-docs/package.json
+++ b/packages/gatsby-theme-apollo-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-apollo-docs",
-  "version": "4.0.7",
+  "version": "4.0.8-alpha.0",
   "main": "index.js",
   "description": "A Gatsby theme for building documentation websites",
   "author": "Trevor Blades <blades@apollographql.com>",
@@ -31,7 +31,7 @@
     "gatsby-remark-rewrite-relative-links": "^1.0.7",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-source-git": "^1.0.1",
-    "gatsby-theme-apollo-core": "^3.0.8",
+    "gatsby-theme-apollo-core": "^3.0.9-alpha.0",
     "gatsby-transformer-remark": "^2.6.30",
     "js-yaml": "^3.13.1",
     "prismjs": "^1.15.0",


### PR DESCRIPTION
This branch changes the method that we use to hide collapsed sidebar nav categories. Previously, we either rendered or did not render the menus, but this prevented Algolia from indexing many of the pages on the site. Now, we switch the `display` CSS rule between `block` and `none`, so that the menu is completely hidden, yet the HTML can be crawled properly.

Fixes https://apollographql.atlassian.net/browse/DX-169