### PR TITLE
Fix titles in MultiCodeBlocks.

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/multi-code-block.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/multi-code-block.js
@@ -60,22 +60,18 @@ export function MultiCodeBlock(props) {
         };
       }
 
-      const nextNode = array[index + 1];
-      if (nextNode && Array.isArray(child.props.children)) {
-        const [title] = child.props.children.filter(
-          child => child.props && child.props.className === 'gatsby-code-title'
-        );
-        if (title) {
+      if (child.props.className === 'gatsby-code-title') {
+        const nextNode = array[index + 1];
+        const title = child.props.children;
+        if (nextNode && title) {
           const lang = getLang(nextNode);
-          if (lang) {
-            return {
-              ...acc,
-              titles: {
-                ...acc.titles,
-                [lang]: title
-              }
-            };
-          }
+          return {
+            ...acc,
+            titles: {
+              ...acc.titles,
+              [lang]: title
+            }
+          };
         }
       }
 
@@ -119,7 +115,7 @@ export function MultiCodeBlock(props) {
           onLanguageChange: handleLanguageChange
         }}
       >
-        {titles[renderedLanguage]}
+        <div className="gatsby-code-title">{titles[renderedLanguage]}</div>
         {codeBlocks[renderedLanguage]}
       </MultiCodeBlockContext.Provider>
     </Container>

--- a/packages/gatsby-theme-apollo-docs/src/components/multi-code-block.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/multi-code-block.js
@@ -63,8 +63,8 @@ export function MultiCodeBlock(props) {
       if (child.props.className === 'gatsby-code-title') {
         const nextNode = array[index + 1];
         const title = child.props.children;
-        if (nextNode && title) {
-          const lang = getLang(nextNode);
+        const lang = getLang(nextNode);
+        if (nextNode && title && lang) {
           return {
             ...acc,
             titles: {


### PR DESCRIPTION
I was going through the Apollo Tutorial today and got confused because some of the code blocks were missing file titles. Here's a small PR that hopefully fixes it.

Before:
![image](https://user-images.githubusercontent.com/10587608/80654341-fcfe6e80-8a49-11ea-9d49-e0556fffa1b9.png)

After:
![image](https://user-images.githubusercontent.com/10587608/80654386-1d2e2d80-8a4a-11ea-99a4-fe15f5cce37c.png)
When dropdown changes:
![image](https://user-images.githubusercontent.com/10587608/80654407-2ae3b300-8a4a-11ea-8c5d-0ae28fec7dc7.png)

Please let me know if anything needs to be changed!