### PR TITLE
Use slug field to generate path

### DIFF
--- a/packages/gatsby-theme-apollo-docs/README.md
+++ b/packages/gatsby-theme-apollo-docs/README.md
@@ -143,7 +143,7 @@ description: What is Apollo Server and what does it do?
 Apollo Server is the best way to quickly build a production-ready, self-documenting API for GraphQL clients, using data from any source.
 ```
 
-Page URLs will be derived from the file paths of your Markdown. You can nest Markdown files within directories to create pages with additional path segments.
+Page URLs will be derived from the file paths of your Markdown. You can nest Markdown files within directories to create pages with additional path segments. You can overwrite this default path by adding a `slug` field to your Markdown frontmatter header.
 
 ## Component shadowing
 

--- a/packages/gatsby-theme-apollo-docs/gatsby-node.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-node.js
@@ -41,6 +41,10 @@ async function onCreateNode(
       getNode
     });
 
+    if(node.frontmatter.slug) {
+      slug = node.frontmatter.slug;
+    }
+
     let category;
     const fileName = parent.name;
     const outputDir = 'social-cards';


### PR DESCRIPTION
This changes gatsby-node.js to allow for the use of slugs.

If the Markdown file supplies a `slug` in the header, it will be used as slug base to generate the node path. If the field is empty or unset, the default file path will be used.

(I could neither find a feature nor an issue for this, so I assumed this is not existing yet? Adding a slug plugin to the gatsby pipeline to work together with the theme does not work straightforward, so I thought adding a check for a slug field here is the easiest and most convenient solution).