### PR TITLE
Add styles for mermaid sequence diagrams

### DIFF
--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -67,6 +67,24 @@ module.exports = ({
             .edgeLabel {
               background-color: white;
             }
+            .messageText, .noteText, .loopText {
+              font-size: 12px;
+            }
+            g rect, polygon.labelBox {
+              stroke-width: 2px;
+            }
+            g rect.actor {
+              stroke: ${colors.tertiary};
+              fill: white;
+            }
+            g rect.note {
+              stroke: ${colors.secondary};
+              fill: white;
+            }
+            g line.loopLine, polygon.labelBox {
+              stroke: ${colors.primary};
+              fill: white;
+            }
           `
         }
       }


### PR DESCRIPTION
Before: 
<img width="587" alt="Screen Shot 2020-06-10 at 1 54 59 PM" src="https://user-images.githubusercontent.com/3433000/84317751-2f5bbb00-ab22-11ea-9a04-3fdbf3260975.png">

After:
<img width="583" alt="Screen Shot 2020-06-10 at 1 55 07 PM" src="https://user-images.githubusercontent.com/3433000/84317776-397db980-ab22-11ea-9909-4f458bd41fdd.png">