### PR TITLE
allow header to render code

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/template.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/template.js
@@ -94,7 +94,9 @@ function createCustomHeading(tag) {
   return ({children, ...props}) => {
     // filter children to avoid rendering nested anchors
     // eslint-disable-next-line react/prop-types
-    const strings = children.filter(child => typeof child === 'string');
+    const strings = children.filter(
+      (child) => typeof child === 'string' || child.type === 'code'
+    );
     return React.createElement(
       tag,
       props,


### PR DESCRIPTION
This PR is to fix the issue on [schema page](https://www.apollographql.com/docs/apollo-server/schema/schema/). The sub headings on the page which contains `<code>` tags are not rendered properly. There is a function responsible which is filtering out only `string` type which has been modified. Screenshot below: 
![20200615-1941-Schema basics - Apollo Server - Apollo GraphQL Docs(1)](https://user-images.githubusercontent.com/6381587/84643164-ce2c5100-af40-11ea-8a5e-5027eed9b7ad.jpg)
![20200615-1941-Schema basics - Apollo Server - Apollo GraphQL Docs(2)(1)](https://user-images.githubusercontent.com/6381587/84643175-d1274180-af40-11ea-9554-561dc4b76634.jpg)

After the fix.
![20200615-1945-Schema basics - Apollo Server - Apollo GraphQL Docs(1)](https://user-images.githubusercontent.com/6381587/84643181-d3899b80-af40-11ea-97a2-fc62ec49efc7.jpg)

