### PR TITLE
feat(gatsby-theme-apollo-docs): adds ignore option

### DIFF
--- a/packages/gatsby-theme-apollo-docs/README.md
+++ b/packages/gatsby-theme-apollo-docs/README.md
@@ -92,7 +92,8 @@ module.exports = {
 | versions          | array  | No       | An array of objects representing the versions that the website should generate                                                          |
 | navConfig         | object | No       | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                              |
 | checkLinksOptions | object | No       | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)                    |
-| ignore            | array  | No       | Files to ignore using [anymatch](https://github.com/es128/anymatch)-compatible definition) pattern.
+| ignore            | array  | No       | Files to ignore using [anymatch](https://github.com/es128/anymatch)-compatible definition pattern
+
 ### `versions`
 
 If omitted, only one version of docs will be built, based on the files in the theme consumer repository. If provided, the `versions` option expects an object mapping older versions' labels to their respective git branch. The current filesystem will still determine the "default" version. The default label for this version is "Latest", but is configurable by the `defaultVersion` option.

--- a/packages/gatsby-theme-apollo-docs/README.md
+++ b/packages/gatsby-theme-apollo-docs/README.md
@@ -92,7 +92,7 @@ module.exports = {
 | versions          | array  | No       | An array of objects representing the versions that the website should generate                                                          |
 | navConfig         | object | No       | An object defining the top-left navigation links (see [`navConfig` reference](#navconfig))                                              |
 | checkLinksOptions | object | No       | Options accepted by [`gastby-remark-check-links`](https://github.com/trevorblades/gatsby-remark-check-links#options)                    |
-
+| ignore            | array  | No       | Files to ignore using [anymatch](https://github.com/es128/anymatch)-compatible definition) pattern.
 ### `versions`
 
 If omitted, only one version of docs will be built, based on the files in the theme consumer repository. If provided, the `versions` option expects an object mapping older versions' labels to their respective git branch. The current filesystem will still determine the "default" version. The default label for this version is "Latest", but is configurable by the `defaultVersion` option.

--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -13,6 +13,7 @@ module.exports = ({
   contentDir = 'content',
   versions = {},
   gaTrackingId,
+  ignore,
   checkLinksOptions
 }) => {
   const gatsbyRemarkPlugins = [
@@ -109,7 +110,8 @@ module.exports = ({
       resolve: 'gatsby-source-filesystem',
       options: {
         path: path.join(root, contentDir),
-        name: 'docs'
+        name: 'docs',
+        ignore,
       }
     },
     {


### PR DESCRIPTION
Allow files to be ignore to be passed into the `gatsby-source-filesystem` to allow for situations,
that not all files should be indexed.  This should help the situation in monorepos where either all the README's 
have to be copied somewhere to processed by Gatsby or you run out of memory, trying scan the world.
