### PR TITLE
Update search shortcut

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/search.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/search.js
@@ -162,7 +162,7 @@ export default function Search(props) {
   // focus the input when the slash key is pressed
   useKey(
     event =>
-      event.keyCode === 191 && event.target.tagName.toUpperCase() !== 'INPUT',
+      event.key === '/' && event.target.tagName.toUpperCase() !== 'INPUT',
     event => {
       event.preventDefault();
       inputRef.current.focus();


### PR DESCRIPTION
Stop relying on `event.keyCode` so the shortcut to focus the search field can be used on every keyboard. Tried on a German keyboard, where it did not work before.