### PR TITLE
Tweak mermaid styles a bit to fix some bugs

### DIFF
--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -68,11 +68,17 @@ module.exports = ({
               fill: none;
               stroke-width: 2px;
             }
-            .edgeLabel {
+            .label, .edgeLabel {
               background-color: white;
+              line-height: 1.3;
+            }
+            .edgeLabel rect {
+              background: none;
+              fill: none;
             }
             .messageText, .noteText, .loopText {
               font-size: 12px;
+              stroke: none;
             }
             g rect, polygon.labelBox {
               stroke-width: 2px;


### PR DESCRIPTION
I think a mermaid update introduced some more structure we need to override styles for

Before:

<img width="645" alt="Screen Shot 2020-08-24 at 9 11 12 PM" src="https://user-images.githubusercontent.com/3433000/91122155-73a12680-e64e-11ea-90ac-cb9b7bb8f7fa.png">

After:

<img width="596" alt="Screen Shot 2020-08-24 at 9 11 31 PM" src="https://user-images.githubusercontent.com/3433000/91122167-7c91f800-e64e-11ea-9838-d8ddee6c2c82.png">
