### PR TITLE
Field table to use two columns instead of three

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/template.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/template.js
@@ -85,9 +85,14 @@ const StyledTable = styled.table({
     td: {
       h6: {
         fontSize: 'inherit',
-        lineHeight: 'inherit'
+        lineHeight: 'inherit',
+        fontWeight: 'bold',
+        marginBottom: '5px'
       },
-      '&:nth-child(2) code': {
+      '&:first-child p': {
+        fontSize: '14px'
+      },
+      '&:first-child p code': {
         color: colors.tertiary
       }
     },


### PR DESCRIPTION
As pointed out by @glasser yesterday, the "name" and "type" columns of a field table are pretty much always tiny compared to the description, and we can instead use a two-column field table that maintains scanability while dedicating more horizontal real estate to the description

Before:

<img width="745" alt="Screen Shot 2020-09-02 at 1 42 34 PM" src="https://user-images.githubusercontent.com/3433000/92034530-39a4e400-ed22-11ea-9fc5-f740ea9bb8a7.png">

After:

<img width="744" alt="Screen Shot 2020-09-02 at 1 42 45 PM" src="https://user-images.githubusercontent.com/3433000/92034549-3f022e80-ed22-11ea-834b-739038a2efe0.png">
