### PR TITLE
Bold current TOC item for improved accessibility

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/section-nav.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/section-nav.js
@@ -19,6 +19,7 @@ const StyledListItem = styled.li(props => ({
   fontSize: '1rem',
   lineHeight: 'inherit',
   color: props.active && colors.primary,
+  fontWeight: props.active && 'bold',
   a: {
     color: 'inherit',
     textDecoration: 'none',


### PR DESCRIPTION
Before:

<img width="201" alt="Screen Shot 2020-09-02 at 2 04 43 PM" src="https://user-images.githubusercontent.com/3433000/92036607-5b539a80-ed25-11ea-894d-3bd73492e5c0.png">

After:

<img width="192" alt="Screen Shot 2020-09-02 at 2 05 04 PM" src="https://user-images.githubusercontent.com/3433000/92036613-5e4e8b00-ed25-11ea-8a02-d69b8bdcc905.png">
