### PR TITLE
Add newline to the end of copied codeblock strings

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/code-block.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/code-block.js
@@ -39,7 +39,7 @@ function CodeBlockHeader(props) {
   const [copied, copyToClipboard] = useCopyToClipboard();
 
   function handleCopy() {
-    copyToClipboard(props.codeRef.current.innerText);
+    copyToClipboard(props.codeRef.current.innerText + '\n');
     trackCustomEvent({
       category: GA_EVENT_CATEGORY_CODE_BLOCK,
       action: 'Copy'


### PR DESCRIPTION
cc @glasser 