### PR TITLE
Move header anchor locations up to avoid search box

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/page-content.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/page-content.js
@@ -59,7 +59,8 @@ const BodyContent = styled.div({
   },
   '*:not(style) +': {
     [['h2', 'h3', 'h4']]: {
-      marginTop: 56
+      marginTop: -60,
+      paddingTop: 100
     }
   },
   img: {


### PR DESCRIPTION
This positive padding + negative margin pushes header anchors higher than the corresponding text, meaning the headers are no longer overlapped by the search box at the top of the page