### PR TITLE
Tweak the spacing between certain headers

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/page-content.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/page-content.js
@@ -21,7 +21,6 @@ const InnerWrapper = styled.div({
   width: 0,
   '.api-ref': {
     h4: {
-      marginTop: 50,
       code: {
         fontSize: '1.1em'
       }
@@ -59,9 +58,17 @@ const BodyContent = styled.div({
     }
   },
   '*:not(style) +': {
-    [['h2', 'h3', 'h4']]: {
-      marginTop: -16,
+    [['h2', 'h3', 'h4', 'h5']]: {
       paddingTop: HEADER_HEIGHT
+    },
+    [['h2']]: {
+      marginTop: -25,
+    },
+    [['h3']]: {
+      marginTop: -30,
+    },
+    [['h4', 'h5']]: {
+      marginTop: -40,
     }
   },
   img: {


### PR DESCRIPTION
Not a huge change, but the spacing between headers was a bit excessive in a few spots.

Before: 

<img width="326" alt="Screen Shot 2020-10-09 at 5 54 36 PM" src="https://user-images.githubusercontent.com/3433000/95641683-93eb4000-0a58-11eb-8ca7-c882346d05e8.png">


After:

<img width="356" alt="Screen Shot 2020-10-09 at 5 54 02 PM" src="https://user-images.githubusercontent.com/3433000/95641688-99e12100-0a58-11eb-9f33-2eaaabf1f839.png">
