### PR TITLE
Add referrer query param to studio link

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/header-button.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/header-button.js
@@ -37,7 +37,7 @@ export default function HeaderButton() {
   return (
     <Container>
       <StyledLink
-        href="https://studio.apollographql.com?utm_source=docs-button"
+        href="https://studio.apollographql.com?utm_source=docs-button&referrer=docs"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
Theres a new referrer param to let studio know what the referrer is, setting it to `docs` for the link to studio.