### PR TITLE
Remove utm param from studio link

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/header-button.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/header-button.js
@@ -37,7 +37,7 @@ export default function HeaderButton() {
   return (
     <Container>
       <StyledLink
-        href="https://studio.apollographql.com?utm_source=docs-button&referrer=docs"
+        href="https://studio.apollographql.com?referrer=docs"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
This PR removes UTM params from a link pointing to Studio to prevent from overriding UTMs we'll be setting from email campaigns.