### PR TITLE
Update GitHub organization and branch names for TypescriptApiBox

### DIFF
--- a/packages/gatsby-theme-apollo-docs/src/components/typescript-api-box.js
+++ b/packages/gatsby-theme-apollo-docs/src/components/typescript-api-box.js
@@ -162,7 +162,8 @@ export class TypescriptApiBox extends Component {
       signature: this._signature(rawData, parameters),
       summary: _summary(rawData),
       groups,
-      repo: 'apollostack/apollo-client',
+      repo: 'apollographql/apollo-client',
+      branch: 'main',
       filepath: rawData.sources[0].fileName,
       lineno: rawData.sources[0].line
     };
@@ -383,7 +384,7 @@ export class TypescriptApiBox extends Component {
           {args.filepath && (
             <Subheading>
               <a
-                href={`https://github.com/${args.repo}/blob/master/${args.filepath}#L${args.lineno}`}
+                href={`https://github.com/${args.repo}/blob/${args.branch}/${args.filepath}#L${args.lineno}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
This code seems to be the source of some incorrect URLs beneath `ApolloClient` core API method headings, like [`(src/core/ApolloClient.ts, line 293)`](https://www.apollographql.com/docs/react/api/core/ApolloClient/#ApolloClient.watchQuery) for `watchQuery`. Hopefully self-explanatory otherwise.