### PR TITLE
Re-add ga4

### DIFF
--- a/packages/gatsby-theme-apollo-docs/theme-options.js
+++ b/packages/gatsby-theme-apollo-docs/theme-options.js
@@ -89,7 +89,7 @@ module.exports = {
   siteName: 'Apollo Docs',
   pageTitle: 'Apollo GraphQL Docs',
   menuTitle: 'Apollo Platform',
-  gaTrackingId: ['UA-74643563-13'],
+  gaTrackingId: ['UA-74643563-13', 'G-0BGG5V2W2K'],
   gtmContainerId: 'GTM-M964NS9',
   algoliaApiKey: '768e823959d35bbd51e4b2439be13fb7',
   algoliaIndexName: 'apollodata',


### PR DESCRIPTION
This PR re-adds the ga4 unified property as it's being removed from the GTM container.