### PR TITLE
Improve contrast of colors in the docs

### DIFF
--- a/packages/gatsby-theme-apollo-core/src/utils/colors.js
+++ b/packages/gatsby-theme-apollo-core/src/utils/colors.js
@@ -3,8 +3,8 @@ const {colors} = require('@apollo/space-kit/colors');
 exports.colors = {
   primary: colors.indigo.dark,
   primaryLight: colors.indigo.lighter,
-  secondary: colors.pink.base,
-  tertiary: colors.teal.dark,
+  secondary: colors.pink.darker,
+  tertiary: colors.teal.darker,
   tertiaryLight: colors.teal.base,
   divider: colors.silver.dark,
   background: colors.silver.light,
@@ -15,10 +15,11 @@ exports.colors = {
   text3: colors.grey.light,
   text4: colors.silver.darker,
   textNotice: colors.yellow.darkest,
-  warning: colors.yellow.base,
+  warning: colors.yellow.darker,
   shadow: colors.black.darker,
   highlight: colors.blue.base,
   highlight2: colors.blue.lighter,
   highlight3: colors.blue.lightest,
+  codeComment: colors.orange.dark,
   hoverOpacity: 0.8
 };

--- a/packages/gatsby-theme-apollo-docs/gatsby-config.js
+++ b/packages/gatsby-theme-apollo-docs/gatsby-config.js
@@ -63,7 +63,7 @@ module.exports = ({
             .node.tertiary rect,
             .node.tertiary circle,
             .node.tertiary polygon {
-              stroke: ${colors.tertiaryLight};
+              stroke: ${colors.tertiary};
             }
             .cluster rect {
               fill: none;

--- a/packages/gatsby-theme-apollo-docs/src/prism.less
+++ b/packages/gatsby-theme-apollo-docs/src/prism.less
@@ -126,7 +126,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: @color-text3;
+  color: @color-codeComment;
 }
 .token.punctuation {
   color: @color-text2;


### PR DESCRIPTION
Using darker versions of brand colors as proposed by @ana-demags

Before:

<img width="444" alt="Screen Shot 2021-08-19 at 5 19 34 PM" src="https://user-images.githubusercontent.com/3433000/130160139-55d0f61f-cbb7-4252-a35c-fc6f354ecac0.png">

After:

<img width="452" alt="Screen Shot 2021-08-19 at 5 19 47 PM" src="https://user-images.githubusercontent.com/3433000/130160147-b53f53ea-3c1e-45d4-ba86-e5260905a793.png">

BTW @ana-demags, I ended up not being able to just use a darker gray for the comment strings, because they ended up looking too similar to regular code. So I'm trying out `orange-dark` here, which I'm partial too because it helps the comments stand out. It's _pretty_ similar to the darker yellow, but that color comes up much less frequently. Let me know what you think!